### PR TITLE
general: seems like hypothesis api repo is gone (https://github.com/judell/Hypothesis)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "Hypothesis"]
 	path = src/hypexport/Hypothesis
-	url = https://github.com/judell/Hypothesis.git # ugh, github actions can't handle ssh?
+	url = https://github.com/karlicoss/Hypothesis.git # ugh, github actions can't handle ssh?
 [submodule "src/hypexport/exporthelpers"]
 	path = src/hypexport/exporthelpers
 	url = https://github.com/karlicoss/exporthelpers.git


### PR DESCRIPTION


Changed to my fork for now instead.

Note that for some reason we're cloning api as a submodule instead of using https://pypi.org/project/hypothesis-api/

IIRC that was for two reasons:

- pypi package wasn't updated for a while
- its name is in conflict with hypothesis testing framework